### PR TITLE
Feature: Add support for `application/x-www-form-urlencoded` encoding

### DIFF
--- a/test/sql/httpclient.test
+++ b/test/sql/httpclient.test
@@ -134,3 +134,68 @@ FROM
 ;
 ----
 S2A_56LPN_20210930_0_L2A
+
+# Confirm the POST function with form request works
+query III
+WITH __input AS (
+  SELECT
+    http_post_form(
+        'https://httpbin.org/delay/0',
+        headers => MAP {
+          'accept': 'application/json',
+        },
+        params => MAP {
+          'limit': 10
+        }
+    ) AS res
+),
+__response AS (
+  SELECT
+    (res->>'status')::INT AS status,
+    (res->>'reason') AS reason,
+    unnest( from_json(((res->>'body')::JSON)->'headers', '{"Host": "VARCHAR"}') ) AS features
+  FROM
+    __input
+)
+SELECT
+  __response.status,
+  __response.reason,
+  __response.Host AS host
+FROM
+  __response
+;
+----
+200	OK	httpbin.org
+
+# Confirm the POST function with form encoding transmits a single value
+query III
+WITH __input AS (
+  SELECT
+    http_post_form(
+        'https://httpbin.org/delay/0',
+        headers => MAP {
+          'accept': 'application/json',
+        },
+        params => MAP {
+          'limit': 10
+        }
+    ) AS res
+),
+__response AS (
+  SELECT
+    (res->>'status')::INT AS status,
+    (res->>'reason') AS reason,
+    unnest( from_json(((res->>'body')::JSON)->'form', '{"limit": "VARCHAR"}') ) AS features
+  FROM
+    __input
+)
+SELECT
+  __response.status,
+  __response.reason,
+  __response.limit AS limit
+FROM
+  __response
+;
+----
+200	OK	10
+


### PR DESCRIPTION
Hey there, thanks for making this library!

I was trying to use this extension to talk to an API but found out that the params are always encoded as a JSON object, while the API I was using expected [`application/x-www-form-urlencoded`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/POST#url-encoded_form_submission) encoding.

I added a new function `http_post_form` that has the same signature as the old `http_post` but uses that encoding instead.
Luckily I was able to reuse a lot of code, since the [`httplib`](https://github.com/duckdb/duckdb/blob/main/third_party/httplib/httplib.hpp#L9064) already has a method for the use case that uses a similar map like the headers that get passed in already.

I found it a bit confusing at first that http_post was posting JSON by default so I noted that down in the README.md too.
But I think it might be a good idea to rename `http_post` to `http_post_json` in the future. Let me know what you think.
It might also be a good idea to consider adding support for `multipart/form-data` and arbitrary text/varchar body for other APIs.

I am open for feedback, but I think this would be a useful feature to talk to more APIs.